### PR TITLE
Add .pdb file to NuGet package for better debugging

### DIFF
--- a/BuildNuGetPackage/BuildFromRelease.bat
+++ b/BuildNuGetPackage/BuildFromRelease.bat
@@ -1,7 +1,6 @@
 @echo off
 
-%~d0
-cd "%~p0"
+pushd "%~dp0"
 
 del *.nu* 2> nul
 del *.dll 2> nul
@@ -12,5 +11,6 @@ copy ..\HappyLogging\bin\Release\HappyLogging.dll > nul
 copy ..\HappyLogging\bin\Release\HappyLogging.pdb > nul
 copy ..\HappyLogging\bin\Release\HappyLogging.xml > nul
 
-copy ..\HappyLogging.nuspec > nul
-nuget pack -NoPackageAnalysis HappyLogging.nuspec
+.\nuget.exe pack ..\HappyLogging.nuspec -BasePath .
+
+popd

--- a/BuildNuGetPackage/BuildFromRelease.bat
+++ b/BuildNuGetPackage/BuildFromRelease.bat
@@ -9,6 +9,7 @@ del *.pdb 2> nul
 del *.xml 2> nul
 
 copy ..\HappyLogging\bin\Release\HappyLogging.dll > nul
+copy ..\HappyLogging\bin\Release\HappyLogging.pdb > nul
 copy ..\HappyLogging\bin\Release\HappyLogging.xml > nul
 
 copy ..\HappyLogging.nuspec > nul

--- a/HappyLogging.nuspec
+++ b/HappyLogging.nuspec
@@ -3,15 +3,15 @@
   <metadata>
     <id>HappyLogging</id>
     <title>HappyLogging</title>
-    <version>1.2.3</version>
+    <version>1.2.4</version>
     <authors>ProductiveRage</authors>
     <owners>ProductiveRage</owners>
-    <licenseUrl>https://bitbucket.org/DanRoberts/happylogging/src/12b208e7f2f10e17d641fabe23e0167e3e01fffe/LICENSE.txt</licenseUrl>
+    <license type="expression">MIT</license>
     <projectUrl>http://www.productiverage.com/happy-logging</projectUrl>
     <iconUrl>https://secure.gravatar.com/avatar/6a1f781d4d5e2d50dcff04f8f049767a?s=200</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Logging library</description>
-    <copyright>Copyright 2016 ProductiveRage</copyright>
+    <copyright>Copyright 2021 ProductiveRage</copyright>
     <tags>C# logging</tags>
   </metadata>
   <files>

--- a/HappyLogging.nuspec
+++ b/HappyLogging.nuspec
@@ -16,6 +16,7 @@
   </metadata>
   <files>
     <file src="HappyLogging.dll" target="lib\net40" />
+    <file src="HappyLogging.pdb" target="lib\net40" />
     <file src="HappyLogging.xml" target="lib\net40" />
   </files>
 </package>

--- a/HappyLogging/Properties/AssemblyInfo.cs
+++ b/HappyLogging/Properties/AssemblyInfo.cs
@@ -9,7 +9,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("HappyLogging")]
-[assembly: AssemblyCopyright("Copyright © Productive Rage 2016")]
+[assembly: AssemblyCopyright("Copyright © Productive Rage 2021")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.2.2.0")]
-[assembly: AssemblyFileVersion("1.2.2.0")]
+[assembly: AssemblyVersion("1.2.4.0")]
+[assembly: AssemblyFileVersion("1.2.4.0")]

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2014 Dan Roberts
+Copyright (c) 2021 Dan Roberts
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
It's nicer to debug issues when the .pdb is available in the NuGet package (provides intellisense and better runtime debugging). Embedding the .pdf file is a simpler approach than using separate symbol packages or snupkgs.

This pull also bumps the version to 1.2.4 for release, updates the copyright years, and updates the nuspec to use `license` instead of `licenseUrl` (since the latter is deprecated - https://docs.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu5125).

The build bat now uses `pushd` and `popd` so it can be ran from solution root without changing the user's working directory, and it also omits copying the nuspec file by referencing it directly from the solution root.